### PR TITLE
Fix success handling condition on road submit

### DIFF
--- a/pub/client.js
+++ b/pub/client.js
@@ -208,7 +208,7 @@ function handleRoadSubmit(){
     return;
   }
   postJSON("/submitroad/"+currentGoal, editor.getRoad(), function(resp) {
-    if (resp.error.length > 0) {
+    if (resp.error) {
         submitMsg.innerHTML = "ERROR! \""+resp.error+"\". Email support@beeminder.com for more help!"
     } else {
       submitMsg.innerHTML = "(successfully submitted road!)";


### PR DESCRIPTION
Previous commit added a condition for error handling, but I broke the success condition, because the error condition caused an error when no error key present on the returned object.

This fixes that error.