### PR TITLE
Fix instaderails after closing do-less loophole

### DIFF
--- a/src/broad.js
+++ b/src/broad.js
@@ -404,6 +404,8 @@
 
   // Appropriate color for a datapoint
   self.dotcolor = ( rd, g, t, v) => {
+    // var tini = rd[1].sta[0] #SCHDEL
+    if (t < g.tini) return bu.Cols.BLCK
     var l = self.lanage( rd, g, t, v )
     if (g.yaw==0 && Math.abs(l) > 1.0) return bu.Cols.GRNDOT
     if (g.yaw==0 && (l==0 && l==1.0)) return bu.Cols.BLUDOT


### PR DESCRIPTION
Changed dotcolor function to say 'black' if asking about a time before
tini. Otherwise for any odom goal starting above zero and do-less goals with
small initial safety buffer, we would think that it was in the red the
day before the goal started, which, by the new derailment criterion
(yesterday = red) would count as derailed on day one!