### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.gitignore
+
+log_file

--- a/jsbrain_server/README_server.md
+++ b/jsbrain_server/README_server.md
@@ -38,7 +38,7 @@ The code is pulled into the image when that Dockerfile is processed in the build
 
 ### Setup
 
-If you are going to run jsbrain for testing, there is a Dockerfile and instructions in docker/.  To run jsbrain_server locally, for instance, for a Beeminder development environment, install node, and, here in the jsbrain_server directory, run
+To run jsbrain_server locally, for instance, for a Beeminder development environment, install node, and, here in the jsbrain_server directory, run
 
 `npm update`
 

--- a/jsbrain_server/README_server.md
+++ b/jsbrain_server/README_server.md
@@ -33,6 +33,8 @@ This reads the file `u+g.bb` (or `slug.bb`) from `/path/to/input`, and
 generates `u+g.png`, `u+g-thumb.png`, `u+g.svg` and `u+g.json` in
 `/path/to/output`. 
 
+By default, the server only listens to localhost--and that's probably what you want.  If you need to bind to other IPs, use the environment variable JSBRAIN_SERVER_BIND.
+
 ### Testing the server
 
 To make sure everything is running, start the server, and then make a request using one of the test files in the automon directory.

--- a/jsbrain_server/README_server.md
+++ b/jsbrain_server/README_server.md
@@ -9,9 +9,36 @@ output with goal parameters.
 
 ## Getting started
 
+You may want to use jsbrain through Docker, or install it locally.
+
+### Docker
+
+#### Caution!
+
+The Dockerfile has *not* been setup for serving in production, and should not be used to do so unless you've audited it yourself!  If you are new to Docker, I suggest spending some time learning about it--but if you can't:
+
+* don't store data you care about inside a container and assume it will be there later
+* don't run Docker stuff on computers that have sensitive information without knowing what you're doing
+
+You can, of course, do what you want, but I feel bad when people get burned.
+
+#### Getting Started and Usage
+
+If you are going to run jsbrain for testing, there is a Dockerfile in docker/.
+
+To get it running, first install Docker on your computer.
+
+Then, go to the root of this repository, and run `docker build --tag jsbrain_server --file jsbrain_server/docker/Dockerfile .`.  This takes all the files in the repository and gives them to the Dockerfile, which is a set of instructions for setting up a Docker image.  It then runs through those instructions, using an aggressive cache, and creates an image.  Beyond its automatic hashy name, we add an extra tag of "jsbrain_server".
+
+Next, we'll run the server with `docker run --publish 127.0.0.1:8777:8777 jsbrain_server`.  It takes the jsbrain_server image, creates a new container from it, ties the port 8777 on the container to our port 8777 (only for localhost!) and starts the container.  This is now running the code that was in the repository at the time the image was created, on our port 8777.
+
+You can stop it with `docker ps` to find the container ID corresponding to this container, and then `docker stop <container ID>`.
+
+The code is pulled into the image when that Dockerfile is processed in the build step, so if you change the code, you'll need to rebuild the image. (Improving this would be awesome!)
+
 ### Setup
 
-To run jsbrain_server, for instance, for a Beeminder development environment, install node, and, here in the jsbrain_server directory, run
+If you are going to run jsbrain for testing, there is a Dockerfile and instructions in docker/.  To run jsbrain_server locally, for instance, for a Beeminder development environment, install node, and, here in the jsbrain_server directory, run
 
 `npm update`
 

--- a/jsbrain_server/docker/Dockerfile
+++ b/jsbrain_server/docker/Dockerfile
@@ -1,0 +1,60 @@
+# jsbrain-server dockerfile, intended for development and testing, but *NOT* for use in production!
+# Written to expect the root of the repository is the context, i.e.
+# cd road/; docker build -f jsbrain_server/docker/Dockerfile .
+
+# Much of this is from https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+# so if you have to edit it, even if you know Docker basics, go check that out.
+
+FROM alpine:edge
+LABEL maintainer="adam@beeminder.com"
+
+# Installs latest Chromium package.
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      yarn
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Not every version of puppeteer works with every version of Chromium
+RUN yarn add puppeteer@1.19.0
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+    && mkdir -p /home/pptruser/Downloads /app \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && chown -R pptruser:pptruser /app
+
+# Install npm
+RUN apk add --no-cache \
+	python3 \
+	npm \
+	build-base
+
+# Preinstall the npm dependencies
+COPY package.json /tmp/package.json
+COPY package-lock.json /tmp/package-lock.json
+RUN cd /tmp && npm update
+RUN mkdir -p /app/jsbrain_server && cp -a /tmp/node_modules /app/jsbrain_server
+
+# Copy the repository into the image at /app
+# It would be nice to figure out how to bring the code in as a volume, so it's easier to develop with (and doesn't require frequent rebuilding of the image), while still using the docker cache for dependencies.
+
+WORKDIR /app
+COPY ./ ./
+# Get the npm dependencies
+WORKDIR /app/jsbrain_server
+RUN npm update
+# set the environment variable so that jsbrain_server binds to all IPs, not just localhost.
+ENV JSBRAIN_SERVER_BIND=0.0.0.0
+USER pptruser
+EXPOSE 8777
+CMD ["npm", "start"] 

--- a/jsbrain_server/jsbrain_server.js
+++ b/jsbrain_server/jsbrain_server.js
@@ -187,9 +187,10 @@ if (cluster.isMaster) {
   createRenderer(cluster.worker.id).then(createdRenderer => {
     renderer = createdRenderer
     console.info(prefix+'Initialized renderer.')
+    const bindip = process.env.JSBRAIN_SERVER_BIND || 'localhost'
       
-    app.listen(port, 'localhost', () => {
-      console.info(prefix+`Listen port on localhost ${port}.`)
+    app.listen(port, bindip, () => {
+      console.info(prefix+`Listen port on ${bindip} ${port}.`)
     })
   }).catch(e => {
     console.error('Fail to initialze renderer.', e)


### PR DESCRIPTION
This adds a Dockerfile and some docs for wrapping up jsbrain in a Docker container.

At the moment, this is for running Beeminder's tests in a Docker container.

I needed to bind jsbrain to 0.0.0.0, so I added an environment variable that can be set to override binding to localhost.