### PR TITLE
Websocket retry

### DIFF
--- a/jsbrain_server/jsbrain_server.js
+++ b/jsbrain_server/jsbrain_server.js
@@ -103,7 +103,6 @@ if (cluster.isMaster) {
     let hostname = os.hostname()
     let { inpath, outpath, slug, user, goal, pyjson, nograph } = req.query
     if (!inpath)                     return res.status(400).send(noinpath)
-    if (inpath == "die")             renderer.die()
     if ((!slug && (!user || !goal))) return res.status(400).send(nofile)
     if ((slug && (user || goal)))    return res.status(400).send(paramconflict)
     var rid = reqcnt++ // Increment and store unique request id

--- a/jsbrain_server/jsbrain_server.js
+++ b/jsbrain_server/jsbrain_server.js
@@ -103,6 +103,7 @@ if (cluster.isMaster) {
     let hostname = os.hostname()
     let { inpath, outpath, slug, user, goal, pyjson, nograph } = req.query
     if (!inpath)                     return res.status(400).send(noinpath)
+    if (inpath == "die")             renderer.die()
     if ((!slug && (!user || !goal))) return res.status(400).send(nofile)
     if ((slug && (user || goal)))    return res.status(400).send(paramconflict)
     var rid = reqcnt++ // Increment and store unique request id

--- a/jsbrain_server/jsbrain_server.js
+++ b/jsbrain_server/jsbrain_server.js
@@ -58,6 +58,13 @@ if (cluster.isMaster) {
   for (var i = 0; i < cpuCount; i += 1)
     cluster.fork();
 
+  // Whenever a worker dies, create a new one.
+  cluster.on('exit', (worker, code, signal) => {
+    console.log('Renderer worker %d died (%s). restarting...',
+      worker.process.pid, signal || code);
+    cluster.fork();
+  });
+
 } else {
 
   var reqcnt = 0  // Keep track of request id for each worker thread

--- a/jsbrain_server/renderer.js
+++ b/jsbrain_server/renderer.js
@@ -31,7 +31,6 @@ class Renderer {
   
   prfinfo(r) { return [this.id,r] }
   prf(r) { return "("+this.id+":"+r+") " }
-  die() { process.exit(1) }
   
   // Renders and returns an available page (tab) within the puppeteer
   // chrome instance. Creates one if all existing ones are found to be

--- a/jsbrain_server/renderer.js
+++ b/jsbrain_server/renderer.js
@@ -329,6 +329,13 @@ async function create( id ) {
         = await puppeteer.launch({ /*headless:false,*/
                                    args: ['--no-sandbox', 
                                           '--allow-file-access-from-files'] })
+  console.log(`Started Puppeteer with pid ${browser.process().pid}`);
+
+  browser.on('disconnected', async () => { 
+      console.error("Browser disconnected.");
+      process.exit(1);
+  });
+
   return new Renderer(browser, id)
 }
 

--- a/jsbrain_server/renderer.js
+++ b/jsbrain_server/renderer.js
@@ -31,6 +31,7 @@ class Renderer {
   
   prfinfo(r) { return [this.id,r] }
   prf(r) { return "("+this.id+":"+r+") " }
+  die() { process.exit(1) }
   
   // Renders and returns an available page (tab) within the puppeteer
   // chrome instance. Creates one if all existing ones are found to be


### PR DESCRIPTION
This fixes #85, probably #99.

Basically, we don't currently handle when the Chrome instance (that puppeteer uses) disconnects.  I rigged it up so that when the worker gets the message that Chrome has disconnected, that the worker dies.  I added logic to jsbrain_server to restart workers when they die.

To test it, I created a way to kill a worker.  I don't really think we should commit it to master, but I wanted to include it here in case folks wanted try it out.  I can add a commit that reverts it, so it stays for posterity's sake.

I also tested it by leaving my jsbrain_server running over a weekend, and then trying to run graphs on it--and it worked for the first time ever!

(I also will rewrite the commit message for "Die when puppeteer disconnects" to not have the (TEST!) in it.)

Thoughts, folks?