### PR TITLE
docker update: install correct pkg

### DIFF
--- a/jsbrain_server/docker/Dockerfile
+++ b/jsbrain_server/docker/Dockerfile
@@ -44,8 +44,8 @@ RUN apk add --no-cache \
 	build-base
 
 # Preinstall the npm dependencies
-COPY package.json /tmp/package.json
-COPY package-lock.json /tmp/package-lock.json
+COPY jsbrain_server/package.json /tmp/package.json
+COPY jsbrain_server/package-lock.json /tmp/package-lock.json
 RUN cd /tmp && npm update
 
 RUN mkdir -p /app/jsbrain_server && cp -a /tmp/node_modules /app/jsbrain_server

--- a/jsbrain_server/package-lock.json
+++ b/jsbrain_server/package-lock.json
@@ -2151,7 +2151,6 @@
       }
     }
   },
-l)
   "dependencies": {
     "@types/node": {
       "version": "14.14.21",
@@ -3493,7 +3492,6 @@ l)
         }
       }
     },
-l)
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -3522,7 +3520,6 @@ l)
         "define-properties": "^1.1.3"
       }
     },
-l)
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3737,7 +3734,6 @@ l)
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
       "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
       "requires": {}
-l)
     },
     "y18n": {
       "version": "5.0.5",


### PR DESCRIPTION
for the docker stuff, for jsbrainserver, we only need to install the
package for the inner repo -- the jsbrain server stuff doesn't need
anything from the root repo other than the src/ dir

* also fixes some syntax errors in the package-lock that got introduced
this week