### PR TITLE
Retry reading bb file if jsbrain can't see it

### DIFF
--- a/jsbrain_server/renderer.js
+++ b/jsbrain_server/renderer.js
@@ -124,9 +124,13 @@ class Renderer {
 
     const bbfile = `${inpath}/${slug}.bb`
     if (!fs.existsSync(bbfile)) {
-      let err = `Could not find file ${bbfile}`
-      msgbuf += (tag+" renderer.js ERROR: "+err+"\n")
-      return { error: err, msgbuf: msgbuf}
+      //Try again!
+      await new Promise(r => setTimeout(r, 250));
+      if (!fs.existSync(bbfile)) {
+        let err = `Could not find file ${bbfile} after second try`
+        msgbuf += (tag+" renderer.js ERROR: "+err+"\n")
+        return { error: err, msgbuf: msgbuf}
+      }
     }
     
     const bburl = encodeURIComponent(inpath)+"/"+encodeURIComponent(slug)+".bb"


### PR DESCRIPTION
Docker bind mounts are really, really slow, and sometimes, we're
seeing beebrain error out because the bb file hasn't shown up in its
shared files by the time it's looking for it.

This just adds a small delay, and a retry, before erroring out.