### PR TITLE
jsonify the graph matrix before submitting to beebody

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -215,7 +215,7 @@ app.post("/submitroad/:goal", (req, resp)=>{
     usr: req.session.username,
     gol: req.params.goal,
     access_token: req.session.access_token,
-    roadall: req.body.road
+    roadall: JSON.stringify(req.body.road)
   }, function(error, response, body) {
     if (error) {
       return console.error('submit failed:', error);


### PR DESCRIPTION
this is a little silly because it is first encoding the roadall param into a json string, and then sending that over to beeminder, but it works because beeminder's api is a silly hybrid between 'application/json' and 'application/x-www-form-urlencoded', but nested arrays are gross in x-www-form-urlencoded params, so we required that the roadall param get submitted as a json string, even if coming from x-www-form-urlencoded way. 